### PR TITLE
#8 fix php warning on /admin/search.php

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -62,9 +62,13 @@ if (is_siteadmin()) {
                 ''
             )
         );
-        $PAGE->requires->js(new moodle_url('/admin/tool/sentry/js/connectiontest.js'));
-        $renderer = $PAGE->get_renderer('tool_sentry');
-        $html = $renderer->render_test_buttons();
+        // Only call this when actually on our settings page, to avoid warnings on other pages.
+        $html = '';
+        if (array_key_exists('section', $_GET) && $_GET['section'] == 'sentryconfig') {
+            $PAGE->requires->js(new moodle_url('/admin/tool/sentry/js/connectiontest.js'));
+            $renderer = $PAGE->get_renderer('tool_sentry');
+            $html = $renderer->render_test_buttons();
+        }
 
         $page->add(new admin_setting_heading(
             'integracaosigaa_test_button',


### PR DESCRIPTION
This fixes the PHP warning on admin/search.php, and makes sure this extra code is only called when the user is actually viewing the settings page of tool_sentry.