### PR TITLE
fix: corrigir origem dos erros no Sentry e adicionar contexto de tasks

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -38,7 +38,6 @@ require_once($CFG->dirroot . '/admin/tool/sentry/vendor/autoload.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class helper {
-
     /** @var bool Whether Sentry has already been initialized. */
     private static $initialized = false;
 
@@ -141,7 +140,7 @@ class helper {
         }
 
         // Try to get the currently running task from Moodle's task manager.
-        // \core\task\manager::get_running_task() is available since Moodle 3.7.
+        // get_running_task() is available since Moodle 3.7.
         if (!method_exists('\core\task\manager', 'get_running_task')) {
             return;
         }
@@ -159,7 +158,7 @@ class helper {
         $tasktype   = $isadhoc ? 'adhoc' : 'scheduled';
 
         // Build a synthetic URL that is human-readable and filterable in Sentry.
-        // Format: cron://hostname/task/component/ShortClassName
+        // Format: cron://hostname/task/component/ShortClassName.
         $url = 'cron://' . $hostname . '/task/' . $component . '/' . $shortclass;
 
         $queryparams = [];
@@ -171,12 +170,12 @@ class helper {
             $scope->setTag('task_id', (string) $taskid);
         }
 
-        // The cron log id is stored in the global $CRON_TASK_LOGID when available
-        // (set by \core\task\logmanager since Moodle 3.7).
+        // The cron log id is available via \core\task\logmanager since Moodle 3.7.
         if (!empty($CFG->task_logmode) && defined('PHPUNIT_TEST') === false) {
-            // Retrieve the log id via the task log manager if possible.
-            if (class_exists('\core\task\logmanager') &&
-                    method_exists('\core\task\logmanager', 'get_current_logid')) {
+            if (
+                class_exists('\core\task\logmanager') &&
+                method_exists('\core\task\logmanager', 'get_current_logid')
+            ) {
                 $logid = \core\task\logmanager::get_current_logid();
                 if ($logid) {
                     $queryparams[] = 'logid=' . $logid;

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -95,19 +95,19 @@ class helper {
      */
     private static function get_moodle_component(string $file): string {
         $patterns = [
-            '#/mod/([^/]+)/#'                   => 'mod_',
-            '#/blocks/([^/]+)/#'                => 'block_',
-            '#/local/([^/]+)/#'                 => 'local_',
-            '#/admin/tool/([^/]+)/#'            => 'tool_',
+            '#/mod/([^/]+)/#'                    => 'mod_',
+            '#/blocks/([^/]+)/#'                 => 'block_',
+            '#/local/([^/]+)/#'                  => 'local_',
+            '#/admin/tool/([^/]+)/#'             => 'tool_',
             '#/availability/condition/([^/]+)/#' => 'availability_',
-            '#/auth/([^/]+)/#'                  => 'auth_',
-            '#/enrol/([^/]+)/#'                 => 'enrol_',
-            '#/report/([^/]+)/#'                => 'report_',
-            '#/theme/([^/]+)/#'                 => 'theme_',
-            '#/question/type/([^/]+)/#'         => 'qtype_',
-            '#/filter/([^/]+)/#'                => 'filter_',
-            '#/course/format/([^/]+)/#'         => 'format_',
-            '#/grade/report/([^/]+)/#'          => 'gradereport_',
+            '#/auth/([^/]+)/#'                   => 'auth_',
+            '#/enrol/([^/]+)/#'                  => 'enrol_',
+            '#/report/([^/]+)/#'                 => 'report_',
+            '#/theme/([^/]+)/#'                  => 'theme_',
+            '#/question/type/([^/]+)/#'          => 'qtype_',
+            '#/filter/([^/]+)/#'                 => 'filter_',
+            '#/course/format/([^/]+)/#'          => 'format_',
+            '#/grade/report/([^/]+)/#'           => 'gradereport_',
         ];
         foreach ($patterns as $pattern => $prefix) {
             if (preg_match($pattern, $file, $m)) {
@@ -115,6 +115,90 @@ class helper {
             }
         }
         return 'core';
+    }
+
+    /**
+     * Detects whether the current execution is a Moodle task (cron/adhoc)
+     * and, if so, enriches the Sentry scope with task-specific context:
+     *
+     *  - A synthetic URL of the form:
+     *      cron://hostname/task/component/classname?id=123&logid=456
+     *    so that Sentry has a non-empty, searchable "url" field.
+     *  - Tags: task_type (scheduled|adhoc), task_class, task_component,
+     *          task_id (adhoc only), task_logid (when available).
+     *
+     * Safe to call even outside CLI; if no task is running it does nothing.
+     *
+     * @param \Sentry\State\Scope $scope Active Sentry scope.
+     * @return void
+     */
+    private static function set_task_context(\Sentry\State\Scope $scope): void {
+        global $CFG;
+
+        // Only meaningful during CLI/cron execution.
+        if (!defined('CLI_SCRIPT') || !CLI_SCRIPT) {
+            return;
+        }
+
+        // Try to get the currently running task from Moodle's task manager.
+        // \core\task\manager::get_running_task() is available since Moodle 3.7.
+        if (!method_exists('\core\task\manager', 'get_running_task')) {
+            return;
+        }
+
+        $task = \core\task\manager::get_running_task();
+        if ($task === null) {
+            return;
+        }
+
+        $classname  = get_class($task);
+        $shortclass = ltrim(strrchr($classname, '\\'), '\\') ?: $classname;
+        $component  = $task->get_component();
+        $hostname   = gethostname() ?: 'localhost';
+        $isadhoc    = ($task instanceof \core\task\adhoc_task);
+        $tasktype   = $isadhoc ? 'adhoc' : 'scheduled';
+
+        // Build a synthetic URL that is human-readable and filterable in Sentry.
+        // Format: cron://hostname/task/component/ShortClassName
+        $url = 'cron://' . $hostname . '/task/' . $component . '/' . $shortclass;
+
+        $queryparams = [];
+
+        // Adhoc tasks have a database id (\core\task\adhoc_task::get_id()).
+        if ($isadhoc && method_exists($task, 'get_id') && $task->get_id()) {
+            $taskid = $task->get_id();
+            $queryparams[] = 'id=' . $taskid;
+            $scope->setTag('task_id', (string) $taskid);
+        }
+
+        // The cron log id is stored in the global $CRON_TASK_LOGID when available
+        // (set by \core\task\logmanager since Moodle 3.7).
+        if (!empty($CFG->task_logmode) && defined('PHPUNIT_TEST') === false) {
+            // Retrieve the log id via the task log manager if possible.
+            if (class_exists('\core\task\logmanager') &&
+                    method_exists('\core\task\logmanager', 'get_current_logid')) {
+                $logid = \core\task\logmanager::get_current_logid();
+                if ($logid) {
+                    $queryparams[] = 'logid=' . $logid;
+                    $scope->setTag('task_logid', (string) $logid);
+                }
+            }
+        }
+
+        if ($queryparams) {
+            $url .= '?' . implode('&', $queryparams);
+        }
+
+        // Set the synthetic URL so Sentry shows it in the "Request" section.
+        $scope->setTag('url', $url);
+        $scope->setTag('task_type', $tasktype);
+        $scope->setTag('task_class', $classname);
+        $scope->setTag('task_component', $component);
+
+        // Also populate the request context so the URL appears in Sentry UI.
+        \Sentry\configureScope(function (\Sentry\State\Scope $s) use ($url): void {
+            $s->setContext('task', ['url' => $url]);
+        });
     }
 
     /**
@@ -136,6 +220,11 @@ class helper {
                 self::$initialized = true;
                 self::inject_sentry_js();
                 \Sentry\init($sentryconfig);
+
+                // Enrich scope with task context when running as cron/adhoc.
+                \Sentry\configureScope(function (\Sentry\State\Scope $scope): void {
+                    self::set_task_context($scope);
+                });
 
                 // Register a custom error handler so Sentry captures the real
                 // origin of each error, not the location of this helper.

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -38,6 +38,7 @@ require_once($CFG->dirroot . '/admin/tool/sentry/vendor/autoload.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class helper {
+
     /** @var bool Whether Sentry has already been initialized. */
     private static $initialized = false;
 
@@ -82,7 +83,46 @@ class helper {
     }
 
     /**
+     * Detects the Moodle component name from a file path.
+     *
+     * Examples:
+     *   /var/www/moodle/mod/assign/lib.php        => mod_assign
+     *   /var/www/moodle/blocks/myblock/block.php  => block_myblock
+     *   /var/www/moodle/local/suap/lib.php        => local_suap
+     *
+     * @param string $file Absolute file path.
+     * @return string Moodle component name or 'core'.
+     */
+    private static function get_moodle_component(string $file): string {
+        $patterns = [
+            '#/mod/([^/]+)/#'                   => 'mod_',
+            '#/blocks/([^/]+)/#'                => 'block_',
+            '#/local/([^/]+)/#'                 => 'local_',
+            '#/admin/tool/([^/]+)/#'            => 'tool_',
+            '#/availability/condition/([^/]+)/#' => 'availability_',
+            '#/auth/([^/]+)/#'                  => 'auth_',
+            '#/enrol/([^/]+)/#'                 => 'enrol_',
+            '#/report/([^/]+)/#'                => 'report_',
+            '#/theme/([^/]+)/#'                 => 'theme_',
+            '#/question/type/([^/]+)/#'         => 'qtype_',
+            '#/filter/([^/]+)/#'                => 'filter_',
+            '#/course/format/([^/]+)/#'         => 'format_',
+            '#/grade/report/([^/]+)/#'          => 'gradereport_',
+        ];
+        foreach ($patterns as $pattern => $prefix) {
+            if (preg_match($pattern, $file, $m)) {
+                return $prefix . $m[1];
+            }
+        }
+        return 'core';
+    }
+
+    /**
      * Initialize sentry.
+     *
+     * Registers a custom PHP error handler so that Sentry receives the real
+     * file and line where each error occurred, instead of always pointing to
+     * this helper class.
      *
      * @param \core\event\base|null $event The event.
      * @return void
@@ -90,11 +130,28 @@ class helper {
     public static function init(?\core\event\base $event = null): void {
         $config = get_config('tool_sentry');
         $sentryconfig = self::get_clean_config($config);
+
         if ($sentryconfig) {
             if (!self::$initialized) {
                 self::$initialized = true;
                 self::inject_sentry_js();
                 \Sentry\init($sentryconfig);
+
+                // Register a custom error handler so Sentry captures the real
+                // origin of each error, not the location of this helper.
+                set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline): bool {
+                    // Respect the @ error-suppression operator.
+                    if (!(error_reporting() & $errno)) {
+                        return false;
+                    }
+                    $exception = new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+                    \Sentry\withScope(function (\Sentry\State\Scope $scope) use ($exception, $errfile): void {
+                        $scope->setTag('moodle_component', self::get_moodle_component($errfile));
+                        \Sentry\captureException($exception);
+                    });
+                    // Return false so Moodle's own error handler also runs.
+                    return false;
+                });
             }
         }
     }
@@ -102,13 +159,31 @@ class helper {
     /**
      * Capture last PHP error (if any).
      *
+     * This is a shutdown fallback for fatal errors (E_ERROR, E_PARSE, etc.)
+     * that cannot be caught by set_error_handler. Non-fatal errors are already
+     * handled by the handler registered in init().
+     *
      * @param \core\event\base|null $event The event.
      * @return void
      */
     public static function geterros(?\core\event\base $event = null): void {
         $config = get_config('tool_sentry');
         if (isset($config->activate) && $config->activate) {
-            \Sentry\captureLastError();
+            $last = error_get_last();
+            $fataltypes = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR];
+            if ($last && in_array($last['type'], $fataltypes, true)) {
+                $exception = new \ErrorException(
+                    $last['message'],
+                    0,
+                    $last['type'],
+                    $last['file'],
+                    $last['line']
+                );
+                \Sentry\withScope(function (\Sentry\State\Scope $scope) use ($exception, $last): void {
+                    $scope->setTag('moodle_component', self::get_moodle_component($last['file']));
+                    \Sentry\captureException($exception);
+                });
+            }
         }
     }
 
@@ -119,8 +194,8 @@ class helper {
      */
     private static function inject_sentry_js(): void {
         global $PAGE;
-        $config = get_config('tool_sentry');
 
+        $config = get_config('tool_sentry');
         if (empty($config->activate) || empty($config->javascriptloader)) {
             return;
         }
@@ -132,17 +207,16 @@ class helper {
         }
 
         $configjson = json_encode($config);
-
         $code = "
         (function() {
-              const script = document.createElement('script');
-              script.src = '$javascriptloader'; // substitua se não for usar PHP
-              script.crossOrigin = 'anonymous';
-              script.onload = function() {
+            const script = document.createElement('script');
+            script.src = '$javascriptloader';
+            script.crossOrigin = 'anonymous';
+            script.onload = function() {
                 Sentry.init($configjson);
-              };
-              document.head.appendChild(script);
-            })();";
+            };
+            document.head.appendChild(script);
+        })();";
 
         $PAGE->requires->js_init_code($code);
     }


### PR DESCRIPTION
## Problema

Todos os erros capturados pelo plugin apareciam no Sentry apontando para
`helper.php (tool_sentry\helper::geterros)` como origem, independente de
onde o erro real havia ocorrido. Isso acontecia porque `captureLastError()`
não tem como saber de onde o erro originou — ele apenas captura o último
erro registrado pelo PHP no momento em que é chamado.

Além disso, erros gerados durante a execução de **tasks agendadas ou adhoc**
(cron) não tinham nenhuma informação útil de contexto: o campo `url` ficava
vazio e era impossível distinguir no Sentry se o erro veio de uma página web
ou de qual task específica.

## O que foi alterado

### 1. `set_error_handler()` para capturar a origem real dos erros

Substituímos o `captureLastError()` por um handler customizado registrado via
`set_error_handler()`. Cada erro agora é capturado como uma `ErrorException`
instanciada com o `$errfile` e `$errline` reais do PHP, de forma que o Sentry
exibe o arquivo e a linha corretos onde o erro de fato ocorreu.

A função `geterros()` foi mantida apenas como fallback de shutdown para erros
**fatais** (`E_ERROR`, `E_PARSE`, `E_CORE_ERROR`, `E_COMPILE_ERROR`) que o
PHP não permite interceptar via `set_error_handler`.

### 2. `get_moodle_component()` — detecção automática de componente

Uma função utilitária extrai o nome do componente Moodle a partir do caminho
do arquivo (ex: `/mod/assign/` → `mod_assign`, `/availability/condition/sectioncompleted/` →
`availability_sectioncompleted`) e o adiciona como tag `moodle_component` em
cada evento.

### 3. `set_task_context()` — contexto para execuções via cron

Quando o código roda em contexto CLI (cron/task), uma nova função detecta a
task em execução via `\core\task\manager::get_running_task()` e enriquece o
escopo do Sentry com:

- **URL sintética** no formato `cron://hostname/task/component/ClassName?id=X&logid=Y`
  para que o Sentry tenha um campo `url` preenchido e filtrável
- **Tags**:
  - `task_type` → `scheduled` ou `adhoc`
  - `task_class` → classe completa da task
  - `task_component` → componente Moodle da task
  - `task_id` → ID da adhoc task no banco (apenas para adhoc tasks)
  - `task_logid` → ID do log do cron via `\core\task\logmanager`

## Resultado

| | Antes | Depois |
|---|---|---|
| Origem do erro | sempre `helper.php` | arquivo e linha reais |
| Componente | desconhecido | tag `moodle_component` automática |
| Erros de task | sem contexto, url vazia | url sintética + 4-5 tags descritivas |
| Erros suprimidos com `@` | capturados indevidamente | respeitados via `error_reporting()` |
| Erros fatais (shutdown) | `captureLastError()` genérico | `ErrorException` com arquivo/linha reais |

## Compatibilidade

- Requer Moodle >= 3.7 para o contexto de tasks (`get_running_task`)
- Usa `method_exists()` e `class_exists()` como guards — degrada silenciosamente em versões anteriores
- Não quebra o handler de erro do próprio Moodle (retorna `false` para propagar)